### PR TITLE
Sanitize gist identifier

### DIFF
--- a/jsturing.js
+++ b/jsturing.js
@@ -710,6 +710,9 @@ function ShowResetMsg(b)
 
 function LoadFromCloud( sID )
 {
+	var n = sID.indexOf('&');
+	sID = sID.substring(0, n != -1 ? n : sID.length);
+
 	/* Get data from github */
 	$.ajax({
 		url: "https://api.github.com/gists/" + sID,


### PR DESCRIPTION
Facebook adds ...&fbclid=... to the end of outbound links, which breaks bookmark links to saved machines.